### PR TITLE
Facilitate execution of Hive authorization commands in impersonation profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # 6) Continue developing
 # 7) `make snapshot' as needed to push snapshot images to dockerhub
 #
-VERSION := 11
+VERSION := 12-SNAPSHOT
 RELEASE_TYPE := $(if $(filter %-SNAPSHOT, $(VERSION)),snapshot,release)
 
 LABEL := com.teradata.git.hash=$(shell git rev-parse HEAD)

--- a/teradatalabs/cdh5-hive-kerberized/Dockerfile
+++ b/teradatalabs/cdh5-hive-kerberized/Dockerfile
@@ -69,6 +69,9 @@ ADD files/conf/hive-site.xml /etc/hive/conf/hive-site.xml
 RUN chown hive:hadoop /etc/hive/conf/hive.keytab
 RUN chmod 644 /etc/hive/conf/hive.keytab
 
+# ENABLE AUTHORIZATION IN HIVE SERVER 
+ADD files/conf/hiveserver2-site.xml /etc/hive/conf/hiveserver2-site.xml
+
 # CREATE PRESTO PRINCIPAL AND KEYTAB
 RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-master@LABS.TERADATA.COM"
 RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-client/presto-master@LABS.TERADATA.COM"

--- a/teradatalabs/cdh5-hive-kerberized/files/conf/hive-site.xml
+++ b/teradatalabs/cdh5-hive-kerberized/files/conf/hive-site.xml
@@ -99,4 +99,14 @@
         <value>hdfs,hive</value>
     </property>
 
+    <property>
+        <name>hive.security.authorization.manager</name>
+        <value>org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdConfOnlyAuthorizerFactory</value>
+    </property>
+
+    <property>
+        <name>hive.security.authorization.task.factory</name>
+        <value>org.apache.hadoop.hive.ql.parse.authorization.HiveAuthorizationTaskFactoryImpl</value>
+    </property>
+
 </configuration>

--- a/teradatalabs/cdh5-hive-kerberized/files/conf/hiveserver2-site.xml
+++ b/teradatalabs/cdh5-hive-kerberized/files/conf/hiveserver2-site.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+
+    <property>
+        <name>hive.security.authorization.manager</name>
+        <value>org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactory</value>
+        <description>SQL standards based Hive authorization</description>
+    </property>
+
+    <property>
+        <name>hive.security.authorization.enabled</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hive.security.authenticator.manager</name>
+        <value>org.apache.hadoop.hive.ql.security.SessionStateUserAuthenticator</value>
+    </property>
+
+    <property>
+        <name>hive.metastore.uris</name>
+        <value> </value>
+    </property>
+
+</configuration>


### PR DESCRIPTION
In order to be able run Hive authorization commands (in product tests or otherwise), we need to enable SQL standards based Hive authorization. As per the document here 
https://cwiki.apache.org/confluence/display/Hive/SQL+Standard+Based+Hive+Authorization#SQLStandardBasedHiveAuthorization-ForHive0.14andNewer, this requires making configuration changes to two files: hive-site.xml and hive-server2.conf.
    
We want to restrict making these changes only to one profile, singlenode-kerberos-hdfs-impersonation, which is the same profile under which product tests under `AUTHORIZATION` group run. This will ensure that only the profile specific tests will run with Hive authorization turned ON; all other tests will not be affected. 

I will later add a commit to bump the version.

I have manually verified that with the locally built image with these changes, I can run Hive authorization commands from inside Presto product test.
