### PR TITLE
Changes required to test _HOST placeholder in kerberos principal

### DIFF
--- a/teradatalabs/cdh5-hive-kerberized/Dockerfile
+++ b/teradatalabs/cdh5-hive-kerberized/Dockerfile
@@ -75,9 +75,11 @@ ADD files/conf/hiveserver2-site.xml /etc/hive/conf/hiveserver2-site.xml
 # CREATE PRESTO PRINCIPAL AND KEYTAB
 RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-master@LABS.TERADATA.COM"
 RUN /usr/sbin/kadmin.local -q "addprinc -randkey presto-client/presto-master@LABS.TERADATA.COM"
+RUN /usr/sbin/kadmin.local -q "addprinc -randkey hive/presto-master@LABS.TERADATA.COM"
 RUN mkdir -p /etc/presto/conf
 RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/presto-server.keytab presto-server/presto-master"
 RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/presto-client.keytab presto-client/presto-master"
+RUN /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/hive-presto-master.keytab hive/presto-master"
 RUN chmod 644 /etc/presto/conf/*.keytab
 
 # CREATE SSL KEYSTORE

--- a/teradatalabs/cdh5-hive-kerberized/files/conf/hdfs-site.xml
+++ b/teradatalabs/cdh5-hive-kerberized/files/conf/hdfs-site.xml
@@ -156,4 +156,14 @@
     <value>*</value>
   </property>
 
+  <property>
+    <name>hadoop.proxyuser.presto-server.groups</name>
+    <value>*</value>
+  </property>
+
+  <property>
+    <name>hadoop.proxyuser.presto-server.hosts</name>
+    <value>*</value>
+  </property>
+
 </configuration>

--- a/teradatalabs/cdh5-hive-master/files/setup.sh
+++ b/teradatalabs/cdh5-hive-master/files/setup.sh
@@ -2,6 +2,10 @@
 
 # 1 format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
+
+# workaround for 'could not open session' bug as suggested here:
+# https://github.com/docker/docker/issues/7056#issuecomment-49371610
+rm -f /etc/security/limits.d/hdfs.conf
 su -c "echo 'N' | hdfs namenode -format" hdfs
 
 # 2 start hdfs

--- a/teradatalabs/cdh5-hive/files/setup.sh
+++ b/teradatalabs/cdh5-hive/files/setup.sh
@@ -5,8 +5,7 @@ chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
 
 # workaround for 'could not open session' bug as suggested here:
 # https://github.com/docker/docker/issues/7056#issuecomment-49371610
-rm /etc/security/limits.d/hdfs.conf
-
+rm -f /etc/security/limits.d/hdfs.conf
 su -c "echo 'N' | hdfs namenode -format" hdfs
 
 # 2 start hdfs

--- a/teradatalabs/hdp2.5-hive/files/setup.sh
+++ b/teradatalabs/hdp2.5-hive/files/setup.sh
@@ -4,6 +4,10 @@ set -ex
 
 # 1 format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
+
+# workaround for 'could not open session' bug as suggested here:
+# https://github.com/docker/docker/issues/7056#issuecomment-49371610
+rm -f /etc/security/limits.d/hdfs.conf
 su -c "echo 'N' | hdfs namenode -format" hdfs
 
 # 2 start hdfs

--- a/teradatalabs/hdp2.5-master/files/setup.sh
+++ b/teradatalabs/hdp2.5-master/files/setup.sh
@@ -4,6 +4,10 @@ set -ex
 
 # 1 format namenode
 chown hdfs:hdfs /var/lib/hadoop-hdfs/cache/
+
+# workaround for 'could not open session' bug as suggested here:
+# https://github.com/docker/docker/issues/7056#issuecomment-49371610
+rm -f /etc/security/limits.d/hdfs.conf
 su -c "echo 'N' | hdfs namenode -format" hdfs
 
 # 2 start hdfs


### PR DESCRIPTION
- Allow `presto-server` user to impersonate. Further `presto-server/_HOST` principal will be used as a proxy user on `presto-master`
- Create `hive/presto-master` principal.  Further `hive/_HOST` principal will be used as a proxy user on `presto-master`