### PR TITLE
A tasty treat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 .idea
 depends
 flags
+graphviz
+dependency_graph.svg
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ INSTALL_JDK_BUILD_ARGS := \
 # Use only BREs in sed for cross-platform compatibility.
 #
 JDK_PATH := $(shell echo $(JDK_RPM) | \
-       	sed 's!jdk-\([0-9][0-9]*\)u\([0-9][0-9]*\).*!/usr/java/jdk1.\1.0_\2!')
+	sed 's!jdk-\([0-9][0-9]*\)u\([0-9][0-9]*\).*!/usr/java/jdk1.\1.0_\2!')
 JDK_PATH_BUILD_ARGS := \
 	--build-arg JDK_PATH=$(JDK_PATH)
 
@@ -146,7 +146,7 @@ include $(TEST_RDEPS)
 
 $(DEPDIR)/%.d: %/Dockerfile $(DEPEND_SH)
 	-mkdir -p $(dir $@)
-	$(SHELL) $(DEPEND_SH) $< $(IMAGE_DIRS) >$@
+	$(SHELL) $(DEPEND_SH) -d $< $(IMAGE_DIRS) >$@
 
 $(FLAGDIR)/%.flags: %/Dockerfile $(FLAG_SH)
 	-mkdir -p $(dir $@)

--- a/depend.sh
+++ b/depend.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 usage() {
-	echo "$0 {-d|-x} {target image} [known images]" >&2
+	echo "$0 {-d|-g|-x} {target image} [known images]" >&2
 }
 
 find_parent() {
@@ -69,7 +69,25 @@ list_ext_image() {
 	echo "$make_friendly_parent"
 }
 
-while getopts ":dx" c; do
+graph_own_image() {
+	cat <<-EOF
+	"$1" [shape=box]
+	"$2" [shape=box]
+	"$1" -> "$2"
+
+EOF
+}
+
+graph_ext_image() {
+	cat <<-EOF
+	"$1" [shape=box]
+	"$2" [shape=house; style=filled; fillcolor="#a0a0a0"]
+	"$1" -> "$2"
+
+EOF
+}
+
+while getopts ":dgx" c; do
 	case $c in
 		d)
 			own_image_function=depfiles_own_image
@@ -78,6 +96,10 @@ while getopts ":dx" c; do
 		x)
 			own_image_function=noop
 			ext_image_function=list_ext_image
+			;;
+		g)
+			own_image_function=graph_own_image
+			ext_image_function=graph_ext_image
 			;;
 		\?)
 			echo "Unrecognized option -$OPTARG" >&2


### PR DESCRIPTION
I cooked this up while I was waiting on builds as I was trying to fix the centos-ssh-oj8 base image. Now you can run `make graph` to automatically create a dependency graph of your images in .svg format.